### PR TITLE
added PlayerProfile

### DIFF
--- a/backend/src/main/java/com/crashcourse/kickoff/tms/club/Club.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/club/Club.java
@@ -35,11 +35,11 @@ public class Club {
     private double ratingDeviation;
 
     @ManyToOne(cascade = CascadeType.PERSIST)
-    private User captain;
+    private PlayerProfile captain;
 
     @OneToMany(mappedBy = "club", cascade = CascadeType.ALL)
     @Size(max = MAX_PLAYERS_IN_CLUB, message = "A club cannot have more than " +  MAX_PLAYERS_IN_CLUB + " players")
-    private List<User> players = new ArrayList<>();
+    private List<PlayerProfile> players = new ArrayList<>();
 
     @ManyToMany(mappedBy = "joinedClubs")
     private List<Tournament> tournaments = new ArrayList<>();

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/club/ClubController.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/club/ClubController.java
@@ -24,7 +24,7 @@ public class ClubController {
     @PostMapping
     public ResponseEntity<?> createClub(@Valid @RequestBody ClubCreationRequest clubRequest) {
         try {
-            Club createdClub = clubService.createClub(clubRequest.getClub(), clubRequest.getCreator());
+            Club createdClub = clubService.createClub(clubRequest.getClub(), clubRequest.getCreatorId());
             return new ResponseEntity<>(createdClub, HttpStatus.CREATED);
         } catch (Exception e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
@@ -64,7 +64,7 @@ public class ClubController {
     @PatchMapping("/{clubId}/transferCaptain")
     public ResponseEntity<?> transferCaptaincy(@PathVariable Long clubId, @RequestBody CaptainTransferRequest request) {
         try {
-            Club updatedClub = clubService.transferCaptaincy(clubId, request.getCurrentCaptain(), request.getNewCaptain());
+            Club updatedClub = clubService.transferCaptaincy(clubId, request.getCurrentCaptainId(), request.getNewCaptainId());
             return new ResponseEntity<>(updatedClub, HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
@@ -72,9 +72,9 @@ public class ClubController {
     }
 
     @PatchMapping("/{clubId}/addPlayer")
-    public ResponseEntity<?> addPlayerToClub(@PathVariable Long clubId, @RequestBody User player) {
+    public ResponseEntity<?> addPlayerToClub(@PathVariable Long clubId, @RequestBody Long playerId) {
         try {
-            Club updatedClub = clubService.addPlayerToClub(clubId, player);
+            Club updatedClub = clubService.addPlayerToClub(clubId, playerId);
             return new ResponseEntity<>(updatedClub, HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
@@ -82,9 +82,9 @@ public class ClubController {
     }
 
     @PatchMapping("/{clubId}/removePlayer")
-    public ResponseEntity<?> removePlayerFromClub(@PathVariable Long clubId, @RequestBody User player) {
+    public ResponseEntity<?> removePlayerFromClub(@PathVariable Long clubId, @RequestBody Long playerId) {
         try {
-            Club updatedClub = clubService.removePlayerFromClub(clubId, player);
+            Club updatedClub = clubService.removePlayerFromClub(clubId, playerId);
             return new ResponseEntity<>(updatedClub, HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/club/ClubService.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/club/ClubService.java
@@ -1,7 +1,7 @@
 package com.crashcourse.kickoff.tms.club;
 
 import com.crashcourse.kickoff.tms.user.model.*;
-
+import com.crashcourse.kickoff.tms.user.repository.PlayerProfileRepository;
 import com.crashcourse.kickoff.tms.club.exception.ClubNotFoundException;
 import com.crashcourse.kickoff.tms.club.exception.PlayerLimitExceededException;
 import com.crashcourse.kickoff.tms.club.exception.ClubAlreadyExistsException;
@@ -19,8 +19,16 @@ public class ClubService {
     @Autowired
     private ClubRepository clubRepository;
 
+    @Autowired
+    private PlayerProfileRepository playerProfileRepository;
+
     // jparepository has automatically implemented crud methods
-    public Club createClub(@Valid Club club, User creator) {
+    public Club createClub(@Valid Club club, Long creatorId) {
+
+        // Find the PlayerProfile by ID
+        PlayerProfile creator = playerProfileRepository.findById(creatorId)
+        .orElseThrow(() -> new RuntimeException("PlayerProfile not found"));
+
         // club name not unique
         if (clubRepository.findByName(club.getName()).isPresent()) {
             throw new ClubAlreadyExistsException("Club name must be unique");
@@ -57,7 +65,13 @@ public class ClubService {
     }
 
     // to transfer captain status to another player in the club
-    public Club transferCaptaincy(Long clubId, User currentCaptain, User newCaptain) throws Exception {
+    public Club transferCaptaincy(Long clubId, Long currentCaptainId, Long newCaptainId) throws Exception {
+        PlayerProfile currentCaptain = playerProfileRepository.findById(currentCaptainId)
+        .orElseThrow(() -> new RuntimeException("currentCaptain not found"));
+
+        PlayerProfile newCaptain = playerProfileRepository.findById(newCaptainId)
+        .orElseThrow(() -> new RuntimeException("newCaptain not found"));
+        
         Club club = clubRepository.findById(clubId).orElseThrow(() -> 
             new ClubNotFoundException("Club with ID " + clubId + " not found"));
     
@@ -98,7 +112,10 @@ public class ClubService {
     }
 
     // add a player to club
-    public Club addPlayerToClub(Long clubId, User player) throws Exception {
+    public Club addPlayerToClub(Long clubId, Long playerId) throws Exception {
+        PlayerProfile player = playerProfileRepository.findById(playerId)
+        .orElseThrow(() -> new RuntimeException("PlayerProfile not found"));
+
         Club club = clubRepository.findById(clubId).orElseThrow(() -> 
             new ClubNotFoundException("Club with ID " + clubId + " not found"));
 
@@ -115,7 +132,10 @@ public class ClubService {
     }
 
     // remove a player from club
-    public Club removePlayerFromClub(Long clubId, User player) throws Exception {
+    public Club removePlayerFromClub(Long clubId, Long playerId) throws Exception {
+        PlayerProfile player = playerProfileRepository.findById(playerId)
+        .orElseThrow(() -> new RuntimeException("PlayerProfile not found"));
+        
         Club club = clubRepository.findById(clubId).orElseThrow(() -> 
             new ClubNotFoundException("Club with ID " + clubId + " not found"));
 

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/club/dto/CaptainTransferRequest.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/club/dto/CaptainTransferRequest.java
@@ -14,9 +14,9 @@ public class CaptainTransferRequest {
 
     @Valid
     @NotNull(message = "Current captain is required")
-    private User currentCaptain;
+    private Long currentCaptainId;
 
     @Valid
     @NotNull(message = "New captain is required")
-    private User newCaptain;
+    private Long newCaptainId;
 }

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/club/dto/ClubCreationRequest.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/club/dto/ClubCreationRequest.java
@@ -19,5 +19,5 @@ public class ClubCreationRequest {
 
     @Valid
     @NotNull(message = "Creator details are required")
-    private User creator;
+    private Long creatorId;
 }

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/controller/UserController.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/controller/UserController.java
@@ -2,18 +2,23 @@ package com.crashcourse.kickoff.tms.user.controller;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.crashcourse.kickoff.tms.user.dto.NewUserDTO;
+import com.crashcourse.kickoff.tms.user.model.PlayerProfile;
 import com.crashcourse.kickoff.tms.user.model.User;
 import com.crashcourse.kickoff.tms.user.service.UserService;
 
 import jakarta.validation.Valid;
 
 @RestController
+@RequestMapping("/users")
 public class UserController {
     private final UserService userService;
 
@@ -21,7 +26,7 @@ public class UserController {
         this.userService = userService;
     }
 
-    @GetMapping("/users")
+    @GetMapping
     public List<User> getUsers() {
         return userService.getUsers();
     }
@@ -32,8 +37,14 @@ public class UserController {
      * @param user
      * @return
      */
-    @PostMapping("/users")
+    @PostMapping
     public User addUser(@Valid @RequestBody NewUserDTO newUserDTO) {
         return userService.addUser(newUserDTO);
+    }
+
+    @PostMapping("/{userId}/playerProfile")
+    public ResponseEntity<PlayerProfile> addPlayerProfile(@PathVariable Long userId, @RequestBody PlayerProfile profile) {
+        PlayerProfile createdProfile = userService.addPlayerProfile(userId, profile);
+        return createdProfile != null ? ResponseEntity.ok(createdProfile) : ResponseEntity.notFound().build();
     }
 }

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/Host.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/Host.java
@@ -1,0 +1,18 @@
+// package com.crashcourse.kickoff.tms.user.model;
+
+// import com.crashcourse.kickoff.tms.club.Club;
+
+// import lombok.*;
+// import jakarta.persistence.*;
+
+// @Entity
+// @Getter
+// @Setter
+// @ToString
+// @AllArgsConstructor
+// @NoArgsConstructor
+// @EqualsAndHashCode
+// public class Host {
+
+    
+// }

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/PlayerPosition.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/PlayerPosition.java
@@ -1,0 +1,8 @@
+package com.crashcourse.kickoff.tms.user.model;
+
+public enum PlayerPosition {
+    POSITION_FORWARD,
+    POSITION_MIDFIELDER,
+    POSITION_DEFENDER,
+    POSITION_GOALKEEPER
+}

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/PlayerProfile.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/PlayerProfile.java
@@ -1,0 +1,40 @@
+package com.crashcourse.kickoff.tms.user.model;
+
+import com.crashcourse.kickoff.tms.club.Club;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.*;
+import jakarta.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class PlayerProfile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name="club_id")
+    private Club club;
+
+
+    // prevents cyclical dependency
+    // i don't know if this is the correct way to do it someone pls think this through
+    @JsonIgnore
+    @OneToOne(mappedBy = "playerProfile", cascade = CascadeType.ALL)
+    private User user;
+
+    // storing one PlayerPosition for now, may change later
+    private PlayerPosition preferredPosition;
+
+    private String profileDescription;
+
+    public boolean isFreeAgent() {
+        return club == null;
+    }
+}

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/Role.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/Role.java
@@ -2,5 +2,7 @@ package com.crashcourse.kickoff.tms.user.model;
 
 public enum Role {
     ROLE_ADMIN,
-    ROLE_USER
+    ROLE_USER,
+    ROLE_PLAYER,
+    ROLE_HOST
 }

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/User.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/model/User.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -22,6 +23,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -62,9 +64,10 @@ public class User implements UserDetails {
     @Column(name = "role")
     private Set<Role> roles;
 
-    @ManyToOne
-    @JoinColumn(name="club_id")
-    private Club club;
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "player_profile_id")
+    private PlayerProfile playerProfile;
+
 
     public User(String username, String password, Set<Role> roles) {
         this.username = username;

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/repository/PlayerProfileRepository.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/repository/PlayerProfileRepository.java
@@ -1,0 +1,10 @@
+package com.crashcourse.kickoff.tms.user.repository;
+
+import com.crashcourse.kickoff.tms.user.model.PlayerProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlayerProfileRepository extends JpaRepository<PlayerProfile, Long> {
+    // Spring Data JPA will automatically implement common methods such as findById, save, delete, etc.
+}

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/service/PlayerProfileService.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/service/PlayerProfileService.java
@@ -1,0 +1,10 @@
+package com.crashcourse.kickoff.tms.user.service;
+
+import java.util.*;
+import com.crashcourse.kickoff.tms.user.model.PlayerProfile;
+
+public interface PlayerProfileService {
+    List<PlayerProfile> getPlayers();
+    PlayerProfile addPlayer(PlayerProfile player);
+    PlayerProfile getPlayer(Long id);  
+}

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/service/PlayerServiceImpl.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/service/PlayerServiceImpl.java
@@ -1,0 +1,5 @@
+package com.crashcourse.kickoff.tms.user.service;
+
+public class PlayerServiceImpl {
+    
+}

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/service/UserService.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/service/UserService.java
@@ -3,10 +3,12 @@ package com.crashcourse.kickoff.tms.user.service;
 import java.util.List;
 
 import com.crashcourse.kickoff.tms.user.dto.NewUserDTO;
+import com.crashcourse.kickoff.tms.user.model.PlayerProfile;
 import com.crashcourse.kickoff.tms.user.model.User;
 
 // Business logic of UserService, actual implementation in UserServiceImpl
 public interface UserService {
     public List<User> getUsers();
     User addUser(NewUserDTO newUserDTO);
+    PlayerProfile addPlayerProfile(Long userId, PlayerProfile playerProfile);
 }

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/user/service/UserServiceImpl.java
@@ -1,12 +1,12 @@
 package com.crashcourse.kickoff.tms.user.service;
 
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.crashcourse.kickoff.tms.user.dto.NewUserDTO;
+import com.crashcourse.kickoff.tms.user.model.PlayerProfile;
 import com.crashcourse.kickoff.tms.user.model.Role;
 import com.crashcourse.kickoff.tms.user.model.User;
 import com.crashcourse.kickoff.tms.user.repository.UserRepository;
@@ -33,5 +33,18 @@ public class UserServiceImpl implements UserService {
         // defaults new users to "user" role
         newUser.setRoles(Set.of(Role.ROLE_USER));
         return users.save(newUser);
+    }
+
+    @Override
+    public PlayerProfile addPlayerProfile(Long userId, PlayerProfile playerProfile) {
+        Optional<User> userOpt = users.findById(userId);
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+            user.setPlayerProfile(playerProfile);
+            playerProfile.setUser(user); // Maintain bidirectional relationship
+            users.save(user);  // Save the user to update profile in DB
+            return playerProfile;
+        }
+        return null;
     }
 }

--- a/backend/src/main/resources/static/ClubTest.http
+++ b/backend/src/main/resources/static/ClubTest.http
@@ -1,0 +1,17 @@
+### Check current clubs
+GET http://localhost:8080/clubs
+Authorization: Basic admin password
+
+### Create new club with creatorId 1
+POST http://localhost:8080/clubs
+Authorization: Basic admin password
+Content-Type: application/json
+
+{
+    "club": {
+        "name": "test",
+        "elo": 1000,
+        "ratingDeviation": 1
+    },
+    "creatorId": 1 
+}

--- a/backend/src/main/resources/static/PlayerTest.http
+++ b/backend/src/main/resources/static/PlayerTest.http
@@ -1,0 +1,13 @@
+### Check admin user exists, and playerProfile is null
+GET http://localhost:8080/users
+Authorization: Basic admin password
+
+### Add player profile to admin
+POST http://localhost:8080/users/1/playerProfile
+Authorization: Basic admin password
+Content-Type: application/json
+
+{
+    "preferredPosition": "POSITION_FORWARD",
+    "profileDescription": "I love football!"
+}


### PR DESCRIPTION
- Created PlayerProfile (as a separate entity from User)
A User can be both a Player and a Host, if we implement Player and Host as subclass of User, everyone that is both Player and Host will have 2 User objects relevant to them (which is pretty wonky)

- Mapped PlayerProfile as OneToOne with User
I added @JsonIgnore in PlayerProfile to get rid of the cyclic dependency between PlayerProfile and User (or else when you try to add PlayerProfile to a User, they recursively print each others' value). I don't know if this is the right way to handle it but ya

- Changed Club references to User to playerProfilleID
I think it makes more sense to take in the ID and handle the getting of PlayerProfile using ID at the service level

- Added http tests for Club and Player