### PR TITLE
Created TournamentJoinAsClub method, Bugfixes

### DIFF
--- a/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
@@ -1,7 +1,6 @@
 package com.crashcourse.kickoff.tms.tournament.controller;
 
-import com.crashcourse.kickoff.tms.tournament.dto.TournamentCreateDTO;
-import com.crashcourse.kickoff.tms.tournament.dto.TournamentResponseDTO;
+import com.crashcourse.kickoff.tms.tournament.dto.*;
 import com.crashcourse.kickoff.tms.tournament.service.TournamentService;
 
 import jakarta.validation.Valid;
@@ -84,5 +83,18 @@ public class TournamentController {
     public ResponseEntity<Void> deleteTournament(@PathVariable Long id) {
         tournamentService.deleteTournament(id);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Join a Tournament.
+     *
+     * @param tournamentJoinDTO DTO containing tournament creation data.
+     * @return ResponseEntity with the new Tournament data and HTTP status.
+     */
+    @PostMapping("/join")
+    public ResponseEntity<TournamentResponseDTO> joinTournamentAsClub(
+            @Valid @RequestBody TournamentJoinDTO tournamentJoinDTO) {
+        TournamentResponseDTO joinedTournament = tournamentService.joinTournamentAsClub(tournamentJoinDTO);
+        return new ResponseEntity<>(joinedTournament, HttpStatus.CREATED);
     }
 }

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/dto/TournamentCreateDTO.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/dto/TournamentCreateDTO.java
@@ -48,8 +48,9 @@ public class TournamentCreateDTO {
      * Maximum number of teams that can participate.
      * Defaults to 0 if not specified.
      */
+    @NotNull(message = "Need a maximum number of teams")
     @Min(value = 0, message = "Maximum teams cannot be negative")
-    private int maxTeams = 0;
+    private Integer maxTeams = 0;
 
     /**
      * Format of the tournament (e.g., Round Robin, Single Elimination).
@@ -61,6 +62,7 @@ public class TournamentCreateDTO {
      * Format specifics if the tournament uses a knockout system.
      * This field is optional and can be null.
      */
+    @NotNull(message = "Knockout format is required")
     private KnockoutFormat knockoutFormat;
 
     /**
@@ -83,9 +85,4 @@ public class TournamentCreateDTO {
     @Min(value = 0, message = "Maximum rank cannot be negative")
     private Integer maxRank;
 
-    /**
-     * List of club identifiers that are joining the tournament at the start.
-     * This field is optional.
-     */
-    private List<@Positive(message = "Club ID must be positive") Long> joinedClubIds;
 }

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/dto/TournamentJoinDTO.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/dto/TournamentJoinDTO.java
@@ -1,0 +1,36 @@
+package com.crashcourse.kickoff.tms.tournament.dto;
+
+import com.crashcourse.kickoff.tms.location.model.*;
+import com.crashcourse.kickoff.tms.tournament.model.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import jakarta.validation.constraints.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Data Transfer Object for creating a Tournament.
+ * This DTO captures all necessary information required to instantiate a Tournament.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TournamentJoinDTO {
+    
+    /*
+     * Club ID
+     */
+    @NotNull(message = "Club ID is required")
+    @Min(value = 1, message = "Club ID must be greater than 0")
+    private Long clubId;
+
+    /*
+     * Tournament ID
+     */
+    @NotNull(message = "Tournament ID is required")
+    @Min(value = 1, message = "Tournament ID must be greater than 0")
+    private Long tournamentId;
+}

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/exception/ClubAlreadyJoinedException.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/exception/ClubAlreadyJoinedException.java
@@ -1,0 +1,14 @@
+package com.crashcourse.kickoff.tms.tournament.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a club attempts to join a tournament it has already joined.
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ClubAlreadyJoinedException extends RuntimeException {
+    public ClubAlreadyJoinedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/exception/TournamentFullException.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/exception/TournamentFullException.java
@@ -1,0 +1,14 @@
+package com.crashcourse.kickoff.tms.tournament.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a club attempts to join a tournament it has already joined.
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class TournamentFullException extends RuntimeException {
+    public TournamentFullException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/model/Tournament.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/model/Tournament.java
@@ -32,13 +32,13 @@ public class Tournament {
     @ManyToOne(cascade = CascadeType.PERSIST)
     private Location location;
 
-    private int maxTeams = 0;
+    private Integer maxTeams = 0;
     private TournamentFormat tournamentFormat;
     private KnockoutFormat knockoutFormat;
     private List<Float> prizePool;
 
-    private int minRank;
-    private int maxRank;
+    private Integer minRank;
+    private Integer maxRank;
 
     @ManyToMany
     @JoinTable(

--- a/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentService.java
+++ b/backend/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentService.java
@@ -1,7 +1,6 @@
 package com.crashcourse.kickoff.tms.tournament.service;
 
-import com.crashcourse.kickoff.tms.tournament.dto.TournamentCreateDTO;
-import com.crashcourse.kickoff.tms.tournament.dto.TournamentResponseDTO;
+import com.crashcourse.kickoff.tms.tournament.dto.*;
 import com.crashcourse.kickoff.tms.tournament.model.Tournament;
 
 import java.util.List;
@@ -17,5 +16,7 @@ public interface TournamentService {
     TournamentResponseDTO updateTournament(Long id, TournamentCreateDTO tournamentCreateDTO);
 
     void deleteTournament(Long id);
+
+    TournamentResponseDTO joinTournamentAsClub(TournamentJoinDTO tournamentJoinDTO);
 
 }

--- a/backend/src/main/resources/static/TournamentTest.http
+++ b/backend/src/main/resources/static/TournamentTest.http
@@ -34,10 +34,33 @@ Content-Type: application/json
   "joinedClubIds": [1, 2]
 }
 
+### Create Tournament with Optional Missing
+POST http://localhost:8080/tournaments
+Authorization: Basic admin:password
+Content-Type: application/application/json
+
+{
+  "name": "Spring Championship",
+  "startDateTime": "2024-05-01T09:00:00",
+  "endDateTime": "2024-05-03T18:00:00",
+  "locationId": 1,
+  "maxTeams": 16,
+  "tournamentFormat": "FIVE_SIDE",
+  "knockoutFormat": "SINGLE_ELIM"
+}
+
 ### View All Tournaments
 GET http://localhost:8080/tournaments
 Authorization: Basic admin:password
 
+### Join Tournament as Club
+POST http://localhost:8080/tournaments/join
+Authorization: Basic admin:password
+Content-Type: application/application/json
+{
+    "clubId": 1,
+    "tournamentId": 1
+}
 
 
 


### PR DESCRIPTION
Created:
- TournamentJoinAsClub method in TournamentServiceImpl
- Added new TournamnentJoinDTO
- Added new exceptions to handle missing tournament, missing club or full tournament
- Updated Tournament.http for testing on postman
- Fixed issue where minRank and maxRank cannot be null in input
- Changed behaviour so that no clubs are included when a tournament is created

To-do:
- No validation for rank or location based requirements for a tournament