### PR TITLE
Remove club, tournament availability bugfixes

### DIFF
--- a/backend/clubs/src/main/java/com/crashcourse/kickoff/tms/security/SecurityConfig.java
+++ b/backend/clubs/src/main/java/com/crashcourse/kickoff/tms/security/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 @EnableWebSecurity
 @Configuration
@@ -53,7 +54,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://localhost:8080"));
+        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/security/SecurityConfig.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/security/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 @EnableWebSecurity
 @Configuration
@@ -53,7 +54,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/dto/PlayerAvailabilityDTO.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/dto/PlayerAvailabilityDTO.java
@@ -9,5 +9,5 @@ public class PlayerAvailabilityDTO {
     private Long tournamentId;  
     private Long playerId;
     private Long clubId;
-    private boolean isAvailable;
+    private boolean available;
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/model/Tournament.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/model/Tournament.java
@@ -6,17 +6,7 @@ import java.util.List;
 
 import com.crashcourse.kickoff.tms.location.model.Location;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/backend/users/src/main/java/com/crashcourse/kickoff/tms/security/SecurityConfig.java
+++ b/backend/users/src/main/java/com/crashcourse/kickoff/tms/security/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.crashcourse.kickoff.tms.security;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.Collections;
+
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -98,7 +100,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,7 +4,6 @@ import { Button } from "./ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
 import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet"
 import Sidebar from './Sidebar'
-import { Toaster } from 'react-hot-toast'
 import { useSelector } from 'react-redux'
 import { selectUsername } from '../store/userSlice'
 
@@ -15,7 +14,6 @@ export default function Header({ isSidebarOpen, setIsSidebarOpen }: { isSidebarO
   const avatarFallbackText = username ? username.slice(0, 2).toUpperCase() : "";
   return (
     <header className="flex justify-between items-center p-4 bg-gray-900">
-      <Toaster />
       <div className="flex items-center">
         <Sheet open={isSidebarOpen} onOpenChange={setIsSidebarOpen}>
           <SheetTrigger asChild>

--- a/frontend/src/components/LandingLayout.tsx
+++ b/frontend/src/components/LandingLayout.tsx
@@ -3,12 +3,14 @@ import { Link, Outlet } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import aboutImage from '../assets/LandingPageWallpaper.jpg';
 import { Helmet } from 'react-helmet';
+import { Toaster } from 'react-hot-toast';
 
 const LandingLayout: React.FC = () => {
   const [showAbout, setShowAbout] = useState(false);
 
   return (
     <div className="flex flex-col min-h-screen bg-gray-900 text-white">
+      <Toaster />
       <Helmet>
         <title>Kickoff</title>
       </Helmet>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import Header from './Header'
 import Sidebar from './Sidebar'
+import { Toaster } from 'react-hot-toast'
 
 export default function Layout() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
 
   return (
     <div className="flex flex-col min-h-screen bg-gray-900 text-white">
+      <Toaster />
       <Header isSidebarOpen={isSidebarOpen} setIsSidebarOpen={setIsSidebarOpen} />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar isOpen={isSidebarOpen} setIsOpen={setIsSidebarOpen} />

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -66,9 +66,10 @@ const Login = () => {
             if (axios.isAxiosError(error)) {
               // Axios-specific error handling
               if (error.response) {
+
                 console.error('Error response:', error.response.data);
                 console.error('Error status:', error.response.status)
-                toast.error(`${error.response.data.message}`, {
+                toast.error(`Invalid username or password!`, {
                     duration: 4000,
                     position: 'top-center',
                   });;

--- a/frontend/src/pages/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage.tsx
@@ -134,7 +134,7 @@ const TournamentPage: React.FC = () => {
       return;
     }
   
-    if (!clubId) {
+    if (!userClub) {
       toast.error("You must be part of a club to mark availability.");
       return;
     }
@@ -143,7 +143,7 @@ const TournamentPage: React.FC = () => {
       const payload = {
         tournamentId: tournamentId,
         playerId: userId,
-        clubId: clubId,  // Use the fetched clubId
+        clubId: userClub.id,  // Use the fetched clubId
         available: availability  
       };
   
@@ -278,7 +278,7 @@ const TournamentPage: React.FC = () => {
         <ShowAvailability 
           availabilities={availabilities} 
           currentUserId={userId} 
-          currentUserClubId={clubId !== null ? clubId : undefined} 
+          currentUserClubId={userClub.id !== null ? userClub.id : undefined} 
         />
       }
       
@@ -343,7 +343,7 @@ const TournamentPage: React.FC = () => {
           </Button>
         )}
         {
-          clubId &&
+          userClub &&
           <Button
             onClick={() => setIsAvailabilityDialogOpen(true)}
             className="bg-blue-600 hover:bg-blue-700"

--- a/frontend/src/pages/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage.tsx
@@ -80,6 +80,10 @@ const TournamentPage: React.FC = () => {
   
       const updatedTournamentData = await fetchTournamentById(selectedTournament.id);
       setSelectedTournament(updatedTournamentData);
+      setJoinedClubsProfiles(prevProfiles => prevProfiles ? 
+        prevProfiles.filter(club => club.id !== clubToRemove.id) 
+        : prevProfiles
+      );
       toast.success('Club removed successfully');
     }
     setIsRemoveDialogOpen(false);

--- a/frontend/src/store/tournamentSlice.ts
+++ b/frontend/src/store/tournamentSlice.ts
@@ -84,7 +84,7 @@ const tournamentSlice = createSlice({
         const { tournamentId, clubId } = action.meta.arg;  // Get tournamentId and clubId from action
         const tournament = state.tournaments.find(t => t.id === tournamentId);
         if (tournament) {
-          tournament.joinedClubs = tournament.joinedClubs.filter(club => club.id !== clubId);  // Remove the club from the tournament
+          tournament.joinedClubsIds = tournament.joinedClubsIds?.filter(club => club !== clubId);
         }
       });
   },

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -4,7 +4,9 @@ export interface Club {
   description?: string;
   players: { id: number }[];
   elo: number;
+  captainId: number;
   ratingDeviation: number;
+  clubDescription: string;
 }
 
 export interface ClubProfile {
@@ -14,4 +16,5 @@ export interface ClubProfile {
   elo: number;
   captainId: number;
   players: number[];
+  clubDescription: string;
 }


### PR DESCRIPTION
Changes
- Remove club correctly removes a club from a tournament now on backend and frontend with instant update
- Tournament availability can be indicated by players (backend issue) and clubs now correctly show players that are available for a specific tournament
- Security config added to all backend microservices to allow all origins for CORS 

Issues
- Had a stomachache halfway through debugging
- Many unused methods in tournament slice