### PR TITLE
feat: tournament match objects

### DIFF
--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/controller/MatchController.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/controller/MatchController.java
@@ -1,0 +1,19 @@
+package com.crashcourse.kickoff.tms.match.controller;
+
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import com.crashcourse.kickoff.tms.match.dto.MatchUpdateDTO;
+
+/**
+ * REST Controller for managing Matches.
+ * Provides endpoints to create, retrieve, update, delete, and list matches.
+ */
+@RestController
+@RequestMapping("/matches")
+@RequiredArgsConstructor
+public class MatchController {
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/controller/MatchController.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/controller/MatchController.java
@@ -2,11 +2,16 @@ package com.crashcourse.kickoff.tms.match.controller;
 
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import jakarta.validation.Valid;
+import jakarta.persistence.EntityNotFoundException;
+
 import lombok.RequiredArgsConstructor;
 
-import com.crashcourse.kickoff.tms.match.dto.MatchUpdateDTO;
+import com.crashcourse.kickoff.tms.match.dto.*;
+import com.crashcourse.kickoff.tms.match.service.MatchService;
+import com.crashcourse.kickoff.tms.security.JwtUtil;
 
 /**
  * REST Controller for managing Matches.
@@ -16,4 +21,39 @@ import com.crashcourse.kickoff.tms.match.dto.MatchUpdateDTO;
 @RequestMapping("/matches")
 @RequiredArgsConstructor
 public class MatchController {
+
+    @Autowired
+    private final MatchService matchService;
+
+    @PostMapping
+    public ResponseEntity<?> createMatch(
+            @RequestBody MatchCreateDTO matchCreateDTO) {
+        try {
+            MatchResponseDTO createdMatch = matchService.createMatch(matchCreateDTO);
+            return new ResponseEntity<>(createdMatch, HttpStatus.CREATED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getMatchById(@PathVariable Long id) {
+        try {
+            MatchResponseDTO matchResponseDTO = matchService.getMatchById(id);
+            return new ResponseEntity<>(matchResponseDTO, HttpStatus.OK);
+        } catch (EntityNotFoundException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateMatch(@PathVariable Long id, @RequestBody MatchUpdateDTO matchUpdateDTO) {
+        try {
+            MatchResponseDTO matchResponseDTO = matchService.updateMatch(id, matchUpdateDTO);
+            return new ResponseEntity<>(matchResponseDTO, HttpStatus.OK);
+        } catch (EntityNotFoundException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+    }
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchCreateDTO.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchCreateDTO.java
@@ -1,0 +1,15 @@
+package com.crashcourse.kickoff.tms.match.dto;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+
+/**
+ * Data Transfer Object for responding with Tournament data.
+ * This DTO excludes sensitive or unnecessary fields and presents data in a client-friendly format.
+ */
+@Data
+@AllArgsConstructor
+public class MatchCreateDTO {
+    private Long tournamentId;
+    private Long parentId;
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchResponseDTO.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchResponseDTO.java
@@ -31,8 +31,8 @@ public class MatchResponseDTO {
     /*
      * Score
      */
-    int club1Score;
-    int club2Score;
+    private int club1Score;
+    private int club2Score;
 
-    Long winningClubId;
+    private Long winningClubId;
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchResponseDTO.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchResponseDTO.java
@@ -1,0 +1,38 @@
+package com.crashcourse.kickoff.tms.match.dto;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+
+/**
+ * Data Transfer Object for responding with Tournament data.
+ * This DTO excludes sensitive or unnecessary fields and presents data in a client-friendly format.
+ */
+@Data
+@AllArgsConstructor
+public class MatchResponseDTO {
+    private Long matchId;
+    private boolean isOver;
+    
+    private Long tournamentId;
+
+    /*
+     * Related Matches
+     */
+    private Long leftChildId;
+    private Long rightChildId;
+    private Long parentMatchId;
+
+    /*
+     * Clubs
+     */
+    private Long club1Id;
+    private Long club2Id;
+
+    /*
+     * Score
+     */
+    int club1Score;
+    int club2Score;
+
+    Long winningClubId;
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchUpdateDTO.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchUpdateDTO.java
@@ -1,5 +1,26 @@
 package com.crashcourse.kickoff.tms.match.dto;
 
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+
+@Data
+@AllArgsConstructor
 public class MatchUpdateDTO {
+    private Long matchId;
+    private boolean isOver;
     
+    /*
+     * Clubs
+     */
+    private Long club1Id;
+    private Long club2Id;
+
+    /*
+     * Score
+     */
+    int club1Score;
+    int club2Score;
+
+    Long winningClubId;
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchUpdateDTO.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchUpdateDTO.java
@@ -19,8 +19,8 @@ public class MatchUpdateDTO {
     /*
      * Score
      */
-    int club1Score;
-    int club2Score;
+    private int club1Score;
+    private int club2Score;
 
-    Long winningClubId;
+    private Long winningClubId;
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchUpdateDTO.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchUpdateDTO.java
@@ -1,0 +1,5 @@
+package com.crashcourse.kickoff.tms.match.dto;
+
+public class MatchUpdateDTO {
+    
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/model/Match.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/model/Match.java
@@ -2,6 +2,8 @@ package com.crashcourse.kickoff.tms.match.model;
 
 import java.util.*;
 
+import com.crashcourse.kickoff.tms.tournament.model.Tournament;
+
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.Data;
@@ -18,7 +20,9 @@ public class Match {
 
     private boolean isOver;
 
-    private Long tournamentId;
+    @ManyToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "tournament_id")
+    private Tournament tournament;
     
     /*
      * Matches are stored in a binary tree data structure

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/model/Match.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/model/Match.java
@@ -1,0 +1,58 @@
+package com.crashcourse.kickoff.tms.match.model;
+
+import java.util.*;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
+@Entity
+@Data
+public class Match {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean isOver;
+
+    private Long tournamentId;
+    
+    /*
+     * Matches are stored in a binary tree data structure
+     */
+
+    @JsonManagedReference
+    @OneToOne
+    @JoinColumn(name = "left_child_id")
+    private Match leftChild;
+
+
+    @JsonManagedReference
+    @OneToOne
+    @JoinColumn(name = "right_child_id")
+    private Match rightChild;
+
+
+    @JsonBackReference
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Match parentMatch;
+
+    /*
+     * Clubs
+     */
+    private Long club1Id;
+    private Long club2Id;
+
+    /*
+     * Score
+     */
+    int club1Score;
+    int club2Score;
+
+    Long winningClubId;
+
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/model/Match.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/model/Match.java
@@ -54,9 +54,9 @@ public class Match {
     /*
      * Score
      */
-    int club1Score;
-    int club2Score;
+    private int club1Score;
+    private int club2Score;
 
-    Long winningClubId;
+    private Long winningClubId;
 
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/repository/MatchRepository.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/repository/MatchRepository.java
@@ -1,0 +1,13 @@
+package com.crashcourse.kickoff.tms.match.repository;
+
+import com.crashcourse.kickoff.tms.match.model.Match;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository interface for Match entities.
+ */
+@Repository
+public interface MatchRepository extends JpaRepository<Match, Long> {
+    // Add custom query methods if needed
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchService.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchService.java
@@ -4,5 +4,7 @@ import com.crashcourse.kickoff.tms.match.model.Match;
 import com.crashcourse.kickoff.tms.match.dto.*;
 
 public interface MatchService {
-    public MatchResponseDTO createMatch(Long tournamentId, Long userId, Long parentId);
+    public MatchResponseDTO createMatch(MatchCreateDTO matchCreateDTO);
+    public MatchResponseDTO getMatchById(Long id);
+    public MatchResponseDTO updateMatch(Long id, MatchUpdateDTO matchUpdateDTO);
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchService.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchService.java
@@ -1,0 +1,8 @@
+package com.crashcourse.kickoff.tms.match.service;
+
+import com.crashcourse.kickoff.tms.match.model.Match;
+import com.crashcourse.kickoff.tms.match.dto.*;
+
+public interface MatchService {
+    public MatchResponseDTO createMatch(Long tournamentId, Long userId, Long parentId);
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchServiceImpl.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchServiceImpl.java
@@ -3,9 +3,13 @@ package com.crashcourse.kickoff.tms.match.service;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+
 import com.crashcourse.kickoff.tms.match.model.Match;
 import com.crashcourse.kickoff.tms.match.repository.MatchRepository;
 import com.crashcourse.kickoff.tms.match.dto.*;
+import com.crashcourse.kickoff.tms.tournament.model.Tournament;
+import com.crashcourse.kickoff.tms.tournament.repository.TournamentRepository;
 
 import lombok.RequiredArgsConstructor;
 import jakarta.persistence.EntityNotFoundException;
@@ -14,36 +18,73 @@ import jakarta.persistence.EntityNotFoundException;
 @RequiredArgsConstructor
 public class MatchServiceImpl implements MatchService {
 
+    @Autowired
     private MatchRepository matchRepository;
 
+    @Autowired
+    private TournamentRepository tournamentRepository;
+
     @Override
-    public MatchResponseDTO createMatch(Long tournamentId, Long userId, Long parentId) {
+    public MatchResponseDTO createMatch(MatchCreateDTO matchCreateDTO) {
 
         Match match = new Match();
-        match.setTournamentId(tournamentId);
+        Tournament tournament = tournamentRepository.findById(matchCreateDTO.getTournamentId())
+            .orElseThrow(() -> new EntityNotFoundException("Parent match not found with id: " + matchCreateDTO.getTournamentId()));
+        match.setTournament(tournament);
 
         /*
          * Update Parent
          */
-        Match parentMatch = matchRepository.findById(parentId)
-            .orElseThrow(() -> new EntityNotFoundException("Parent match not found with id: " + parentId));
-        match.setParentMatch(parentMatch);
+        Long parentId = matchCreateDTO.getParentId();
+        if (parentId > 0) {
+            Match parentMatch = matchRepository.findById(parentId)
+                .orElseThrow(() -> new EntityNotFoundException("Parent match not found with id: " + parentId));
+            match.setParentMatch(parentMatch);
 
-        if (parentMatch.getLeftChild() == null) {
-            parentMatch.setLeftChild(match);
-        } else if (parentMatch.getRightChild() == null) {
-            parentMatch.setRightChild(match);
-        } else {
-            throw new RuntimeException("Parent match already has two children matches.");
+            if (parentMatch.getLeftChild() == null) {
+                parentMatch.setLeftChild(match);
+            } else if (parentMatch.getRightChild() == null) {
+                parentMatch.setRightChild(match);
+            } else {
+                throw new RuntimeException("Parent match already has two children matches.");
+            }
+            matchRepository.save(parentMatch);
+
         }
 
         /*
          * Save matches
          */
-        matchRepository.save(parentMatch);
         Match savedMatch = matchRepository.save(match);
 
         return mapToResponseDTO(savedMatch);
+    }
+
+    @Override
+    public MatchResponseDTO getMatchById(Long id) {
+        Match foundMatch = matchRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("Match not found with ID: " + id));
+        return mapToResponseDTO(foundMatch);
+    }
+
+    @Override
+    public MatchResponseDTO updateMatch(Long id, MatchUpdateDTO matchUpdateDTO) {
+        Match foundMatch = matchRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("Match not found with ID: " + id));
+
+        foundMatch.setOver(matchUpdateDTO.isOver());
+        foundMatch.setClub1Id(matchUpdateDTO.getClub1Id());
+        foundMatch.setClub2Id(matchUpdateDTO.getClub2Id());
+        foundMatch.setClub1Score(matchUpdateDTO.getClub1Score());
+        foundMatch.setClub2Score(matchUpdateDTO.getClub2Score());
+        foundMatch.setWinningClubId(matchUpdateDTO.getWinningClubId());
+        
+        /*
+         * Save to repository
+         */
+        matchRepository.save(foundMatch);
+
+        return mapToResponseDTO(foundMatch);
     }
 
     /**
@@ -53,14 +94,27 @@ public class MatchServiceImpl implements MatchService {
      * @return TournamentResponseDTO
      */
     private MatchResponseDTO mapToResponseDTO(Match match) {
+        Long leftChildId = 0L;
+        if (match.getLeftChild() != null) {
+            leftChildId = match.getLeftChild().getId();
+        }
+        Long rightChildId = 0L;
+        if (match.getRightChild() != null) {
+            rightChildId = match.getRightChild().getId();
+        }
+        Long parentId = 0L;
+        if (match.getParentMatch() != null) {
+            parentId = match.getParentMatch().getId();
+        }
+
         return new MatchResponseDTO(
                 match.getId(),
                 match.isOver(),
 
-                match.getTournamentId(),
-                match.getLeftChild().getId(),
-                match.getRightChild().getId(),
-                match.getParentMatch().getId(),
+                match.getTournament().getId(),
+                leftChildId,
+                rightChildId,
+                parentId,
 
                 match.getClub1Id(),
                 match.getClub2Id(),

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchServiceImpl.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchServiceImpl.java
@@ -1,0 +1,74 @@
+package com.crashcourse.kickoff.tms.match.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import com.crashcourse.kickoff.tms.match.model.Match;
+import com.crashcourse.kickoff.tms.match.repository.MatchRepository;
+import com.crashcourse.kickoff.tms.match.dto.*;
+
+import lombok.RequiredArgsConstructor;
+import jakarta.persistence.EntityNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class MatchServiceImpl implements MatchService {
+
+    private MatchRepository matchRepository;
+
+    @Override
+    public MatchResponseDTO createMatch(Long tournamentId, Long userId, Long parentId) {
+
+        Match match = new Match();
+        match.setTournamentId(tournamentId);
+
+        /*
+         * Update Parent
+         */
+        Match parentMatch = matchRepository.findById(parentId)
+            .orElseThrow(() -> new EntityNotFoundException("Parent match not found with id: " + parentId));
+        match.setParentMatch(parentMatch);
+
+        if (parentMatch.getLeftChild() == null) {
+            parentMatch.setLeftChild(match);
+        } else if (parentMatch.getRightChild() == null) {
+            parentMatch.setRightChild(match);
+        } else {
+            throw new RuntimeException("Parent match already has two children matches.");
+        }
+
+        /*
+         * Save matches
+         */
+        matchRepository.save(parentMatch);
+        Match savedMatch = matchRepository.save(match);
+
+        return mapToResponseDTO(savedMatch);
+    }
+
+    /**
+     * Maps Tournament entity to TournamentResponseDTO.
+     *
+     * @param tournament Tournament entity
+     * @return TournamentResponseDTO
+     */
+    private MatchResponseDTO mapToResponseDTO(Match match) {
+        return new MatchResponseDTO(
+                match.getId(),
+                match.isOver(),
+
+                match.getTournamentId(),
+                match.getLeftChild().getId(),
+                match.getRightChild().getId(),
+                match.getParentMatch().getId(),
+
+                match.getClub1Id(),
+                match.getClub2Id(),
+
+                match.getClub1Score(),
+                match.getClub2Score(),
+                match.getWinningClubId()
+        );
+    }
+
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
@@ -2,19 +2,8 @@ package com.crashcourse.kickoff.tms.tournament.controller;
 
 import java.util.List;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
 
 import com.crashcourse.kickoff.tms.security.JwtUtil;
 import com.crashcourse.kickoff.tms.tournament.dto.PlayerAvailabilityDTO;


### PR DESCRIPTION
Added:
- Match objects with a planned binary tree implementation
- Create, read and update matches
- Tested on Postman

Issues:
- Currently, relationship between Match and Tournament is unidirectional