### PR TITLE
feat:update-match

### DIFF
--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/controller/MatchController.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/controller/MatchController.java
@@ -39,13 +39,13 @@ public class MatchController {
         }
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<?> updateMatch(@PathVariable Long id, @RequestBody MatchUpdateDTO matchUpdateDTO) {
-        try {
-            MatchResponseDTO matchResponseDTO = matchService.updateMatch(id, matchUpdateDTO);
-            return new ResponseEntity<>(matchResponseDTO, HttpStatus.OK);
-        } catch (EntityNotFoundException e) {
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
-        }
-    }
+    // @PutMapping("{tournamentId}/{matchId}")
+    // public ResponseEntity<?> updateMatch(@PathVariable Long tournamentId, @PathVariable Long matchId, @RequestBody MatchUpdateDTO matchUpdateDTO) {
+    //     try {
+    //         MatchResponseDTO matchResponseDTO = matchService.updateMatch(tournamentId, matchId, matchUpdateDTO);
+    //         return new ResponseEntity<>(matchResponseDTO, HttpStatus.OK);
+    //     } catch (EntityNotFoundException e) {
+    //         return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+    //     }
+    // }
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchUpdateDTO.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/dto/MatchUpdateDTO.java
@@ -7,7 +7,9 @@ import lombok.AllArgsConstructor;
 @Data
 @AllArgsConstructor
 public class MatchUpdateDTO {
-    private Long matchId;
+    /*
+     * Match Id covered in Path Variable
+     */
     private boolean isOver;
     
     /*

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/repository/RoundRepository.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/repository/RoundRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoundRepository extends JpaRepository<Round, Long> {
+    Round findRoundByRoundNumber(Long roundNumber);
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/BracketService.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/BracketService.java
@@ -3,12 +3,16 @@ package com.crashcourse.kickoff.tms.match.service;
 import java.util.*;
 
 import com.crashcourse.kickoff.tms.match.model.Bracket;
+import com.crashcourse.kickoff.tms.match.model.Match;
+import com.crashcourse.kickoff.tms.match.dto.MatchUpdateDTO;
+import com.crashcourse.kickoff.tms.tournament.model.Tournament;
 
 /*
  * Abstract class since bracket differs by format
  */
 public interface BracketService {
     Bracket createBracket(Long tournamentId, int numberOfClubs);
+    Match updateMatch(Tournament tournament, Match match, MatchUpdateDTO matchUpdateDTO);
     // Bracket seedClubs(Long tournamentId, List<Long> clubIds);
     // Long getBracketWinnerId(Long tournamentId);
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchService.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchService.java
@@ -9,5 +9,5 @@ import com.crashcourse.kickoff.tms.match.dto.*;
 public interface MatchService {
     Match createMatch(Long tournamentId, Long matchNumber);
     Match getMatchById(Long id);
-    MatchResponseDTO updateMatch(Long id, MatchUpdateDTO matchUpdateDTO);
+    // MatchResponseDTO updateMatch(Long tournamentId, Long matchId, MatchUpdateDTO matchUpdateDTO);
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchServiceImpl.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/MatchServiceImpl.java
@@ -10,6 +10,7 @@ import com.crashcourse.kickoff.tms.match.model.Round;
 
 import com.crashcourse.kickoff.tms.match.repository.MatchRepository;
 import com.crashcourse.kickoff.tms.match.repository.RoundRepository;
+
 import com.crashcourse.kickoff.tms.match.dto.*;
 import com.crashcourse.kickoff.tms.tournament.model.Tournament;
 import com.crashcourse.kickoff.tms.tournament.repository.TournamentRepository;
@@ -27,6 +28,9 @@ public class MatchServiceImpl implements MatchService {
     @Autowired
     private RoundRepository roundRepository;
 
+    @Autowired
+    private TournamentRepository tournamentRepository;
+
     /*
      * Matches can now only be created through
      * create bracket
@@ -35,7 +39,7 @@ public class MatchServiceImpl implements MatchService {
     public Match createMatch(Long roundId, Long matchNumber) {
         Match match = new Match();
         match.setMatchNumber(matchNumber);
-        
+
         Round round = roundRepository.findById(roundId)
             .orElseThrow(() -> new EntityNotFoundException("Round not found with id: " + roundId));
         match.setRound(round);
@@ -49,33 +53,7 @@ public class MatchServiceImpl implements MatchService {
             .orElseThrow(() -> new EntityNotFoundException("Match not found with ID: " + id));
     }
 
-    @Override
-    public MatchResponseDTO updateMatch(Long id, MatchUpdateDTO matchUpdateDTO) {
-        Match foundMatch = matchRepository.findById(id)
-            .orElseThrow(() -> new EntityNotFoundException("Match not found with ID: " + id));
-
-        /*
-         * Update Score
-         */
-        foundMatch.setClub1Score(matchUpdateDTO.getClub1Score());
-        foundMatch.setClub2Score(matchUpdateDTO.getClub2Score());
-        foundMatch.setWinningClubId(matchUpdateDTO.getWinningClubId());
-
-        /*
-         * If over, send winner to next round
-         */
-        if (matchUpdateDTO.isOver()) {
-            
-        }
-        
-        /*
-         * Save to repository
-         */
-        matchRepository.save(foundMatch);
-
-        return mapToResponseDTO(foundMatch);
-    }
-
+  
     /**
      * Maps Tournament entity to TournamentResponseDTO.
      *

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/SingleEliminationService.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/SingleEliminationService.java
@@ -3,8 +3,12 @@ package com.crashcourse.kickoff.tms.match.service;
 import java.util.*;
 
 import com.crashcourse.kickoff.tms.match.model.Bracket;
+import com.crashcourse.kickoff.tms.match.model.Match;
+import com.crashcourse.kickoff.tms.tournament.model.Tournament;
+import com.crashcourse.kickoff.tms.match.dto.MatchUpdateDTO;
 
 public interface SingleEliminationService extends BracketService {
     Bracket createBracket(Long tournamentId, int numberOfClubs);
+    Match updateMatch(Tournament tournament, Match match, MatchUpdateDTO matchUpdateDTO);
     // Bracket seedClubs(Long tournamentId, List<Long> clubIds);
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/SingleEliminationServiceImpl.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/SingleEliminationServiceImpl.java
@@ -67,12 +67,22 @@ public class SingleEliminationServiceImpl implements SingleEliminationService {
         }
 
         Long matchNumber = match.getMatchNumber();
+        Long club1Id = matchUpdateDTO.getClub1Id();
+        Long club2Id = matchUpdateDTO.getClub2Id();
         Long winningClubId = matchUpdateDTO.getWinningClubId();
-        
+
         /*
          * If over, send winner to next round
          */
         if (matchUpdateDTO.isOver()) {
+
+            /*
+             * Validation for No Clubs: if seeding is done correctly, there should be
+             * no empty matches since every preceding match will have at least 1 club
+             */
+            if (club1Id == null && club2Id == null) {
+                throw new RuntimeException("No clubs in match.");
+            }
 
             match.setOver(true);
             

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/SingleEliminationServiceImpl.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/service/SingleEliminationServiceImpl.java
@@ -7,7 +7,11 @@ import org.springframework.http.*;
 
 import com.crashcourse.kickoff.tms.match.model.*;
 import com.crashcourse.kickoff.tms.match.service.*;
+import com.crashcourse.kickoff.tms.match.dto.MatchUpdateDTO;
 import com.crashcourse.kickoff.tms.match.repository.SingleEliminationBracketRepository;
+import com.crashcourse.kickoff.tms.match.repository.MatchRepository;
+import com.crashcourse.kickoff.tms.match.repository.RoundRepository;
+
 
 import com.crashcourse.kickoff.tms.tournament.model.*;
 import com.crashcourse.kickoff.tms.tournament.repository.TournamentRepository;
@@ -21,6 +25,8 @@ public class SingleEliminationServiceImpl implements SingleEliminationService {
 
     private final TournamentRepository tournamentRepository;
     private final SingleEliminationBracketRepository bracketRepository;
+    private final RoundRepository roundRepository;
+    private final MatchRepository matchRepository;
     private final RoundService roundService;
 
     @Override
@@ -37,10 +43,9 @@ public class SingleEliminationServiceImpl implements SingleEliminationService {
         SingleEliminationBracket bracket = new SingleEliminationBracket();
         List<Round> bracketRounds = new ArrayList<>();
 
-        Long roundNumber = 0L;
         while (numberOfRounds > 0) {
             int size = (int) Math.pow(2, numberOfRounds);
-            bracketRounds.add(roundService.createRound(size, roundNumber + 1L));
+            bracketRounds.add(roundService.createRound(size, 0L + numberOfRounds));
             numberOfRounds--;
         }
     
@@ -51,4 +56,77 @@ public class SingleEliminationServiceImpl implements SingleEliminationService {
         tournament.setBracket(bracket);
         return bracket;
     }
+
+    @Override
+    public Match updateMatch(Tournament tournament, Match match, MatchUpdateDTO matchUpdateDTO) {
+        /*
+         * Validation
+         */
+        if (tournament == null) {
+            throw new EntityNotFoundException("No tournament found.");
+        }
+        if (match == null) {
+            throw new EntityNotFoundException("No match found.");
+        }
+
+        if (!(tournament.getBracket() instanceof SingleEliminationBracket seBracket)) {
+            throw new RuntimeException("Wrong bracket format.");
+        }
+
+        Long matchNumber = match.getMatchNumber();
+        Long winningClubId = matchUpdateDTO.getWinningClubId();
+        Long club1Id = matchUpdateDTO.getClub1Id();
+        Long club2Id = matchUpdateDTO.getClub2Id();
+        if (winningClubId != club1Id && winningClubId != club2Id) {
+            throw new RuntimeException("Invalid winning club");
+        } 
+
+        /*
+         * Update Score
+         */
+        match.setClub1Score(matchUpdateDTO.getClub1Score());
+        match.setClub2Score(matchUpdateDTO.getClub2Score());
+        match.setWinningClubId(winningClubId);
+
+        /*
+         * If over, send winner to next round
+         */
+        if (matchUpdateDTO.isOver()) {
+
+            match.setOver(true);
+            
+            /*
+             * Note that roundNumber counts downwards 
+             * so we know if its the last round
+             */
+            if (match.getRound().getRoundNumber() == 1) {
+                tournament.setWinningClubId(matchUpdateDTO.getWinningClubId());
+            } else {
+                List<Round> rounds = seBracket.getRounds();
+                /*
+                 * -1 for next round, -1 since we use 1 index
+                 */
+                Long roundNumber = match.getRound().getRoundNumber();
+                Round nextRound = roundRepository.findRoundByRoundNumber(roundNumber - 1);
+                List<Match> matches = nextRound.getMatches();
+
+                /*
+                 * -1 to account for 1 indexing again
+                 */
+                Match nextMatch = matches.get((int)Math.ceil(matchNumber/2.0) - 1);
+                /*
+                 * Note that we start from index 1
+                 */
+                if (matchNumber % 2 == 1) {
+                    nextMatch.setClub1Id(winningClubId);
+                } else {
+                    nextMatch.setClub2Id(winningClubId);
+                }
+                matchRepository.save(nextMatch);
+            }
+        }
+        
+        return matchRepository.save(match);
+    }
+
 }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
@@ -6,6 +6,7 @@ import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
 import com.crashcourse.kickoff.tms.security.JwtUtil;
+
 import com.crashcourse.kickoff.tms.tournament.dto.PlayerAvailabilityDTO;
 import com.crashcourse.kickoff.tms.tournament.dto.TournamentCreateDTO;
 import com.crashcourse.kickoff.tms.tournament.dto.TournamentJoinDTO;
@@ -14,10 +15,15 @@ import com.crashcourse.kickoff.tms.tournament.dto.TournamentUpdateDTO;
 import com.crashcourse.kickoff.tms.tournament.model.Tournament;
 import com.crashcourse.kickoff.tms.tournament.model.TournamentFilter;
 import com.crashcourse.kickoff.tms.tournament.service.TournamentService;
+
 import com.crashcourse.kickoff.tms.match.model.Bracket;
+import com.crashcourse.kickoff.tms.match.model.Match;
+import com.crashcourse.kickoff.tms.match.service.MatchService;
+import com.crashcourse.kickoff.tms.match.dto.*;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import jakarta.persistence.EntityNotFoundException;
 
 /**
  * REST Controller for managing Tournaments.
@@ -29,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class TournamentController {
 
     private final TournamentService tournamentService;
+    private final MatchService matchService;
     private final JwtUtil jwtUtil; // final for constructor injection
 
     /**
@@ -114,6 +121,16 @@ public class TournamentController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body("You are not authorized to start this tournament.");
         }
         return ResponseEntity.ok(tournamentService.startTournament(id));
+    }
+
+    @PutMapping("{tournamentId}/{matchId}")
+    public ResponseEntity<?> updateMatchInTournament(@PathVariable Long tournamentId, @PathVariable Long matchId, @RequestBody MatchUpdateDTO matchUpdateDTO) {
+        try {
+            Match match = tournamentService.updateMatchInTournament(tournamentId, matchId, matchUpdateDTO);
+            return new ResponseEntity<>(match, HttpStatus.OK);
+        } catch (EntityNotFoundException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
     }
 
     /**

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
@@ -124,9 +124,10 @@ public class TournamentController {
     }
 
     @PutMapping("{tournamentId}/{matchId}")
-    public ResponseEntity<?> updateMatchInTournament(@PathVariable Long tournamentId, @PathVariable Long matchId, @RequestBody MatchUpdateDTO matchUpdateDTO) {
+    public ResponseEntity<?> updateMatchInTournament(@PathVariable Long tournamentId, @PathVariable Long matchId, 
+        @RequestBody MatchUpdateDTO matchUpdateDTO, @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) String token) {
         try {
-            Match match = tournamentService.updateMatchInTournament(tournamentId, matchId, matchUpdateDTO);
+            Match match = tournamentService.updateMatchInTournament(tournamentId, matchId, matchUpdateDTO, token);
             return new ResponseEntity<>(match, HttpStatus.OK);
         } catch (EntityNotFoundException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
@@ -164,7 +164,7 @@ public class TournamentController {
         try {
             joinedTournament = tournamentService.joinTournamentAsClub(tournamentJoinDTO, token);
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e);
         }
 
         return new ResponseEntity<>(joinedTournament, HttpStatus.CREATED);

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/model/Tournament.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/model/Tournament.java
@@ -24,6 +24,7 @@ public class Tournament {
 
     private String name;
     private boolean isOver;
+    private Long winningClubId;
 
     private LocalDateTime startDateTime;
     private LocalDateTime endDateTime;

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/model/Tournament.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/model/Tournament.java
@@ -24,7 +24,6 @@ public class Tournament {
 
     private String name;
     private boolean isOver;
-    private Long winningClubId;
 
     private LocalDateTime startDateTime;
     private LocalDateTime endDateTime;

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentService.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentService.java
@@ -7,6 +7,8 @@ import com.crashcourse.kickoff.tms.tournament.model.PlayerAvailability;
 import com.crashcourse.kickoff.tms.tournament.model.Tournament;
 import com.crashcourse.kickoff.tms.tournament.model.TournamentFilter;
 import com.crashcourse.kickoff.tms.match.model.Bracket;
+import com.crashcourse.kickoff.tms.match.model.Match;
+import com.crashcourse.kickoff.tms.match.dto.MatchUpdateDTO;
 
 public interface TournamentService {
 
@@ -19,6 +21,7 @@ public interface TournamentService {
     TournamentResponseDTO updateTournament(Long id, TournamentUpdateDTO tournamentUpdateDTO);
 
     TournamentResponseDTO startTournament(Long id);
+    Match updateMatchInTournament(Long tournamentId, Long matchId, MatchUpdateDTO matchUpdateDTO);
 
     void deleteTournament(Long id);
 

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentService.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentService.java
@@ -21,7 +21,8 @@ public interface TournamentService {
     TournamentResponseDTO updateTournament(Long id, TournamentUpdateDTO tournamentUpdateDTO);
 
     TournamentResponseDTO startTournament(Long id);
-    Match updateMatchInTournament(Long tournamentId, Long matchId, MatchUpdateDTO matchUpdateDTO);
+    
+    Match updateMatchInTournament(Long tournamentId, Long matchId, MatchUpdateDTO matchUpdateDTO, String token);
 
     void deleteTournament(Long id);
 

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentServiceImpl.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentServiceImpl.java
@@ -17,6 +17,9 @@ import com.crashcourse.kickoff.tms.club.model.ClubProfile;
 
 import com.crashcourse.kickoff.tms.match.model.*;
 import com.crashcourse.kickoff.tms.match.service.*;
+import com.crashcourse.kickoff.tms.match.dto.MatchUpdateDTO;
+import com.crashcourse.kickoff.tms.match.dto.MatchResponseDTO;
+import com.crashcourse.kickoff.tms.match.repository.MatchRepository;
 
 import com.crashcourse.kickoff.tms.location.model.Location;
 import com.crashcourse.kickoff.tms.location.repository.LocationRepository;
@@ -32,6 +35,7 @@ import com.crashcourse.kickoff.tms.tournament.repository.TournamentRepository;
 import com.crashcourse.kickoff.tms.security.JwtUtil;
 
 import jakarta.persistence.EntityNotFoundException;
+
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -44,6 +48,8 @@ public class TournamentServiceImpl implements TournamentService {
     
     private final TournamentRepository tournamentRepository;
     private final LocationRepository locationRepository;
+    private final MatchRepository matchRepository;
+
     private final LocationService locationService;
     private final PlayerAvailabilityRepository playerAvailabilityRepository;
 
@@ -129,6 +135,38 @@ public class TournamentServiceImpl implements TournamentService {
             tournament.setBracket(bracket);
             Tournament savedTournament = tournamentRepository.save(tournament);
             return mapToResponseDTO(savedTournament);
+        } else {
+            throw new UnsupportedOperationException("Unsupported tournament format: " + knockoutFormat);
+        }
+    }
+
+    public Match updateMatchInTournament(Long tournamentId, Long matchId, MatchUpdateDTO matchUpdateDTO) {
+        Tournament tournament = tournamentRepository.findById(tournamentId)
+            .orElseThrow(() -> new EntityNotFoundException("Tournament not found with ID: " + tournamentId));
+
+        Match match = matchRepository.findById(matchId)
+            .orElseThrow(() -> new EntityNotFoundException("Match not found with ID: " + matchId));
+
+        /*
+         * Update Clubs
+         */
+        match.setClub1Id(matchUpdateDTO.getClub1Id());
+        match.setClub2Id(matchUpdateDTO.getClub2Id());
+
+        /*
+         * Update Score
+         */
+        match.setClub1Score(matchUpdateDTO.getClub1Score());
+        match.setClub2Score(matchUpdateDTO.getClub2Score());
+        match.setWinningClubId(matchUpdateDTO.getWinningClubId());
+
+        /*
+         * Adding this to handle different bracket progression formats
+         */
+        KnockoutFormat knockoutFormat = tournament.getKnockoutFormat();
+        if (KnockoutFormat.SINGLE_ELIM.equals(knockoutFormat)) {
+            Match updatedMatch = singleEliminationService.updateMatch(tournament, match, matchUpdateDTO);
+            return updatedMatch;
         } else {
             throw new UnsupportedOperationException("Unsupported tournament format: " + knockoutFormat);
         }

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentServiceImpl.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/service/TournamentServiceImpl.java
@@ -329,7 +329,6 @@ public class TournamentServiceImpl implements TournamentService {
         headers.set("Authorization", jwtToken);
         HttpEntity<Void> request = new HttpEntity<>(headers);
 
-        // Fetch the ClubProfile from the club service
         ResponseEntity<ClubProfile> response = restTemplate.exchange(
                 clubServiceUrl,
                 HttpMethod.GET,
@@ -367,9 +366,18 @@ public class TournamentServiceImpl implements TournamentService {
             throw new TournamentFullException("Tournament is already full.");
         }
 
-        // Add the club to the tournament
-        tournament.getJoinedClubIds().add(clubId);
+        /*
+         * Validation for elo range
+         */
+        double elo = clubProfile.getElo();
+        if (tournament.getMinRank() != null && elo < tournament.getMinRank()) {
+            throw new RuntimeException("Club does not meet tournament minimum elo requirement.");
+        }
+        if (tournament.getMaxRank() != null && elo > tournament.getMaxRank()) {
+            throw new RuntimeException("Club exceeds tournament maximum elo requirement.");
+        }
 
+        tournament.getJoinedClubIds().add(clubId);
         Tournament updatedTournament = tournamentRepository.save(tournament);
         return mapToResponseDTO(updatedTournament);
     }


### PR DESCRIPTION
Changes:
- When a match is updated to be over, it will send the winning team into the next match (not based on score, but based on WinningClubId; this is to account for possible additional complexity, away goal rules or penalties etc.)
- Validation added to check if clubs are valid, if winningclubid is one of the two clubs

Issues:
- It is assumed that a match in a later round (further into the tournament) can be updated even if its prior matches are not over, this is done for easier testing and to account for possible bye rounds
- No logic currently to account for matches where there is only 1 or 0 clubs in the match