### PR TITLE
fix:tournament-service-match

### DIFF
--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/client/ClubServiceClient.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/client/ClubServiceClient.java
@@ -1,0 +1,52 @@
+package com.crashcourse.kickoff.tms.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.HttpClientErrorException;
+
+import com.crashcourse.kickoff.tms.security.JwtTokenProvider;
+import com.crashcourse.kickoff.tms.club.ClubProfile;
+
+@Component
+public class ClubServiceClient {
+
+    private final RestTemplate restTemplate;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /*
+     * should this go into .env?
+     */
+    private final String clubUrl = "http://localhost:8082/api/v1/clubs/";
+
+    public ClubServiceClient(RestTemplate restTemplate, JwtTokenProvider jwtTokenProvider) {
+        this.restTemplate = restTemplate;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public ClubProfile getClubProfileById (Long clubId, String token) {
+        String url = clubUrl + clubId;
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", jwtTokenProvider.getToken(token));
+
+        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<ClubProfile> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    requestEntity,
+                    ClubProfile.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return response.getBody();
+            } else {
+                throw new RuntimeException("Failed to retrieve ClubProfile for ID: " + clubId);
+            }
+        } catch (HttpClientErrorException e) {
+            throw new RuntimeException("Error retrieving ClubProfile for ID: " + clubId + ". Error: " + e.getMessage());
+        }
+    }
+}

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/club/ClubProfile.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/club/ClubProfile.java
@@ -1,4 +1,4 @@
-package com.crashcourse.kickoff.tms.club.model;
+package com.crashcourse.kickoff.tms.club;
 
 import java.util.List;
 

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/model/Match.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/match/model/Match.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Entity
 @Data
+@Table(name = "GAME") // Match is a reserved SQL keyword
 public class Match {
 
     @Id

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/security/JwtTokenProvider.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/security/JwtTokenProvider.java
@@ -1,0 +1,14 @@
+package com.crashcourse.kickoff.tms.security;
+
+import org.springframework.stereotype.Service;
+import java.time.Instant;
+
+@Service
+public class JwtTokenProvider {
+
+    public String getToken(String token) {
+        return token.substring(7);
+    }
+
+}
+

--- a/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
+++ b/backend/tournaments/src/main/java/com/crashcourse/kickoff/tms/tournament/controller/TournamentController.java
@@ -164,6 +164,7 @@ public class TournamentController {
         try {
             joinedTournament = tournamentService.joinTournamentAsClub(tournamentJoinDTO, token);
         } catch (Exception e) {
+            System.out.println(e);
             return ResponseEntity.status(HttpStatus.CONFLICT).body(e);
         }
 


### PR DESCRIPTION
Changes:
- Changed the name of the Match object SQL table to no longer use match, since it is a reserved keyword in SQL syntax. The table is now "GAME" (open to feedback on a better naming for the table)
- Decoupled the cross-service communication and processing of JwtToken from the tournament service method, now handled in JwtTokenProvider and JwtUtil (can consider combining both together)