### PR TITLE
feat/tournament and user routing and UI changes

### DIFF
--- a/frontend/src/components/ViewProfile.tsx
+++ b/frontend/src/components/ViewProfile.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { PlayerPosition, PlayerProfile, UserPublicDetails} from '../types/profile';
-import { fetchPlayerProfileById, fetchUserPublicInfoById} from '../services/userService';
+import { PlayerPosition, PlayerProfile, UserPublicDetails } from '../types/profile';
+import { fetchPlayerProfileById, fetchUserPublicInfoById } from '../services/userService';
 import { getClubByPlayerId } from '../services/clubService';
 import { Club } from '../types/club';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -14,9 +14,7 @@ import { selectUserId } from '../store/userSlice';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
 
-
 export default function ViewProfile() {
-
   const navigate = useNavigate();
   let userId = useSelector(selectUserId);
 
@@ -42,7 +40,6 @@ export default function ViewProfile() {
     }
 
     const fetchUserProfile = async () => {
-
       try {
         const viewedUser = await fetchUserPublicInfoById(userId);
         setViwedUser(viewedUser);
@@ -98,7 +95,6 @@ export default function ViewProfile() {
     fetchUserProfile();
   }, [userId]);
 
-
   const formatPosition = (position: string) => {
     return position.replace('POSITION_', '').charAt(0) + position.replace('POSITION_', '').slice(1).toLowerCase();
   };
@@ -110,24 +106,24 @@ export default function ViewProfile() {
 
   return (
     <div className="container mx-auto p-6 max-w-4xl">
-      {id &&
+      {id && (
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </CardHeader>
-      }
+      )}
       <Card className="mb-6">
         <CardContent>
           <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
             <img
               src={viewedUser?.profilePictureUrl || `https://picsum.photos/seed/${userId + 2000}/200/200`}
-              alt={`${playerProfile ? playerProfile.username : null}'s profile`}
+              alt={`${playerProfile ? playerProfile.username : 'User'}'s profile`}
               className="w-32 h-32 rounded-full object-cover"
             />
             <div className="text-center md:text-left">
-              <div className='flex items-center gap-2'>
-                <h1 className="text-3xl font-bold">{viewedUser ? viewedUser.username : null}</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-3xl font-bold">{viewedUser ? viewedUser.username : 'User'}</h1>
                 {!id && (
                   <Button
                     variant="ghost"
@@ -141,9 +137,11 @@ export default function ViewProfile() {
                 )}
               </div>
 
-              <p className="text-muted-foreground">ID: {viewedUser ? viewedUser.id : null}</p>
+              <p className="text-muted-foreground">ID: {viewedUser ? viewedUser.id : 'N/A'}</p>
               <div className="mt-4 flex flex-wrap gap-2 justify-center md:justify-start">
-                <p className="text-muted-foreground">{profileDescription || 'No user description provided.'}</p>
+                <p className="text-muted-foreground">
+                  {profileDescription || 'No user description provided.'}
+                </p>
               </div>
             </div>
           </div>
@@ -151,7 +149,7 @@ export default function ViewProfile() {
       </Card>
 
       <div className="grid gap-6 md:grid-cols-2">
-        {playerProfile ?
+        {/* Club Information Card */}
         <Card>
           <CardHeader>
             <CardTitle className="text-xl font-semibold flex items-center gap-2">
@@ -159,9 +157,12 @@ export default function ViewProfile() {
               Club Information
             </CardTitle>
           </CardHeader>
-          <CardContent onClick={() => navigate(`/clubs/${club?.id}`)}>
+          <CardContent>
             {club ? (
-              <div className="flex items-center gap-4">
+              <div
+                className="flex items-center gap-4 cursor-pointer"
+                onClick={() => navigate(`/clubs/${club.id}`)}
+              >
                 <img
                   src={`https://picsum.photos/seed/club-${club.id}/800/200`}
                   alt={`${club.name} logo`}
@@ -173,13 +174,21 @@ export default function ViewProfile() {
                 </div>
               </div>
             ) : (
-              <p className="text-muted-foreground">Not associated with a club.</p>
+              <div className="flex flex-col items-center">
+                <p className="text-muted-foreground">Not associated with a club.</p>
+                <Button
+                  className="mt-4"
+                  onClick={() => navigate('/clubs')}
+                >
+                  Find or Create a Club
+                </Button>
+              </div>
             )}
           </CardContent>
-        </Card> : <></>}
+        </Card>
 
-        {/* conditional rendering of preferred positions */}
-        {playerProfile ?
+        {/* Player Positions Card */}
+        {playerProfile && (
           <Card>
             <CardHeader>
               <CardTitle className="text-xl font-semibold flex items-center gap-2">
@@ -198,8 +207,10 @@ export default function ViewProfile() {
               ))}
             </CardContent>
           </Card>
-          : <></>}
+        )}
       </div>
+
+      {/* Hosted Tournaments Section */}
       {tournamentsHosted && tournamentsHosted.length > 0 && (
         <Card className="mt-6">
           <CardHeader>
@@ -211,17 +222,17 @@ export default function ViewProfile() {
           <CardContent>
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {tournamentsHosted.map((tournament) => (
-                tournament.id &&
-                <TournamentCard
-                  key={tournament.id}
-                  tournament={tournament}
-                />
+                tournament.id && (
+                  <TournamentCard
+                    key={tournament.id}
+                    tournament={tournament}
+                  />
+                )
               ))}
             </div>
           </CardContent>
         </Card>
       )}
     </div>
-
   );
 }

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Input } from '../components/ui/input';
 import { Button } from '../components/ui/button';
 import { PlayerPosition } from '../types/profile';
@@ -30,6 +30,9 @@ export default function SignupPage() {
     });
     const [confirmPasswordError, setConfirmPasswordError] = useState('');
     const [preferredPositions, setPreferredPositions] = useState<PlayerPosition[]>([]);
+
+    // Determine if the password is valid
+    const passwordIsValid = Object.values(passwordCriteria).every(Boolean);
 
     // Toggle password visibility
     const togglePasswordVisibility = () => {
@@ -91,7 +94,7 @@ export default function SignupPage() {
         }
 
         // Check if password meets all criteria
-        if (!passwordCriteria.length || !passwordCriteria.capital || !passwordCriteria.lowercase || !passwordCriteria.symbol || !passwordCriteria.number) {
+        if (!passwordIsValid) {
             toast.error('Password does not meet all criteria.', {
                 duration: 3000,
                 position: 'top-center',
@@ -195,31 +198,44 @@ export default function SignupPage() {
                                     onBlur={() => setShowPasswordCriteria(false)}
                                     type={showPassword ? 'text' : 'password'}
                                     required
-                                    className="w-full"
+                                    className={`w-full ${
+                                        password.length > 0
+                                            ? passwordIsValid
+                                                ? 'border-green-500'
+                                                : 'border-red-500'
+                                            : 'border-gray-300'
+                                    }`}
                                     placeholder="Enter Password"
                                 />
-                                <div className="absolute inset-y-0 right-0 flex items-center px-4 text-gray-600 cursor-pointer" onClick={togglePasswordVisibility}>
-                                    <img src={showPassword ? eyePassword : eyePasswordOff} alt="Toggle Password Visibility" className="h-5 w-5" />
+                                <div
+                                    className="absolute inset-y-0 right-0 flex items-center px-4 text-gray-600 cursor-pointer"
+                                    onClick={togglePasswordVisibility}
+                                >
+                                    <img
+                                        src={showPassword ? eyePassword : eyePasswordOff}
+                                        alt="Toggle Password Visibility"
+                                        className="h-5 w-5"
+                                    />
                                 </div>
                             </div>
 
                             {showPasswordCriteria && (
-                                <div className="absolute top-0 left-full ml-4 bg-gray-700 text-white p-4 rounded-lg shadow-lg text-sm w-64 z-50">
-                                    <div className="relative">
+                                <div className="absolute top-full left-0 mt-2 bg-gray-700 text-white p-4 rounded-lg shadow-lg text-sm w-full z-50">
+                                    <div className="relative space-y-1">
                                         <p className={passwordCriteria.length ? 'text-green-500' : 'text-red-500'}>
-                                            At least 8 characters
+                                            • At least 8 characters
                                         </p>
                                         <p className={passwordCriteria.capital ? 'text-green-500' : 'text-red-500'}>
-                                            Includes a capital letter
+                                            • Includes a capital letter
                                         </p>
                                         <p className={passwordCriteria.lowercase ? 'text-green-500' : 'text-red-500'}>
-                                            Includes a lowercase letter
+                                            • Includes a lowercase letter
                                         </p>
                                         <p className={passwordCriteria.symbol ? 'text-green-500' : 'text-red-500'}>
-                                            Includes a symbol
+                                            • Includes a symbol (!@#$%^&*)
                                         </p>
                                         <p className={passwordCriteria.number ? 'text-green-500' : 'text-red-500'}>
-                                            Includes a number
+                                            • Includes a number
                                         </p>
                                     </div>
                                 </div>
@@ -237,11 +253,24 @@ export default function SignupPage() {
                                     onBlur={handleConfirmPasswordBlur}
                                     type={showPassword ? 'text' : 'password'}
                                     required
-                                    className="w-full"
+                                    className={`w-full ${
+                                        confirmPassword.length > 0
+                                            ? password === confirmPassword
+                                                ? 'border-green-500'
+                                                : 'border-red-500'
+                                            : 'border-gray-300'
+                                    }`}
                                     placeholder="Confirm Password"
                                 />
-                                <div className="absolute inset-y-0 right-0 flex items-center px-4 text-gray-600 cursor-pointer" onClick={togglePasswordVisibility}>
-                                    <img src={showPassword ? eyePassword : eyePasswordOff} alt="Toggle Password Visibility" className="h-5 w-5" />
+                                <div
+                                    className="absolute inset-y-0 right-0 flex items-center px-4 text-gray-600 cursor-pointer"
+                                    onClick={togglePasswordVisibility}
+                                >
+                                    <img
+                                        src={showPassword ? eyePassword : eyePasswordOff}
+                                        alt="Toggle Password Visibility"
+                                        className="h-5 w-5"
+                                    />
                                 </div>
                             </div>
                         </div>
@@ -288,7 +317,7 @@ export default function SignupPage() {
                         </a>
                     </div>
                 </form>
-            </div >
-        </div >
+            </div>
+        </div>
     );
 }

--- a/frontend/src/pages/TournamentPage.tsx
+++ b/frontend/src/pages/TournamentPage.tsx
@@ -22,11 +22,14 @@ import { fetchUserPublicInfoById } from '../services/userService';
 import { ArrowLeft } from 'lucide-react';
 import TournamentBracket from '../components/TournamentBracket';
 
-
+import { selectIsAdmin } from '../store/userSlice'
+import ManageTournamentButton from '../components/ManageTournamentButton';
 
 const TournamentPage: React.FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
+
+  const isAdmin = useSelector(selectIsAdmin);
 
   useEffect(() => {
     dispatch(fetchUserClubAsync());
@@ -425,6 +428,19 @@ const TournamentPage: React.FC = () => {
         </div>
       </div>
 
+      <div className='flex'>
+          {isAdmin && (
+          <ManageTournamentButton
+            tournament={selectedTournament}
+            onActionComplete={() => {
+              // Optional: Refresh tournament data or perform other actions
+              fetchTournamentById(tournamentId!).then(setSelectedTournament);
+              toast.success("Tournament management actions completed.");
+            }}
+          />
+        )}
+        </div>
+
       {/* Show bracket if it exists */}
       {selectedTournament.bracket && (
         <div className="bg-gray-800 rounded-lg p-6 mb-6">
@@ -439,6 +455,7 @@ const TournamentPage: React.FC = () => {
             }}
           />
         </div>
+        
       )}
     </>
   );

--- a/frontend/src/pages/TournamentsPage.tsx
+++ b/frontend/src/pages/TournamentsPage.tsx
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../components/
 import { toast } from 'react-hot-toast'
 import TournamentCard from '../components/TournamentCard'
 import CreateTournament from '../components/CreateTournament'
+import CreateClub from '../components/CreateClub'
 import { Tournament } from '../types/tournament'
 import { PlayerAvailabilityDTO } from '../types/playerAvailability'
 import { getPlayerAvailability } from '../services/tournamentService'
@@ -28,6 +29,7 @@ export default function Component() {
   const [isLeaveDialogOpen, setIsLeaveDialogOpen] = useState(false)
   const [selectedTournament, setSelectedTournament] = useState<Tournament | null>(null)
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
+  const [isCreateClubDialogOpen, setIsCreateClubDialogOpen] = useState(false) // State for CreateClub dialog
   const [isCaptainAlertOpen, setIsCaptainAlertOpen] = useState(false)
   const [isAvailabilityDialogOpen, setIsAvailabilityDialogOpen] = useState(false)
   const [availabilityAlertMessage, setAvailabilityAlertMessage] = useState('')
@@ -198,6 +200,22 @@ export default function Component() {
 
   return (
     <>
+    {/* Notification Card for Users Without a Club */}
+    {!userClub && (
+        <div className="bg-red-600 text-white rounded-lg p-4 lg:p-6 mb-6 flex items-center space-x-4">
+          <div className="bg-white rounded-full p-2 lg:p-3">
+            <svg className="h-6 w-6 lg:h-8 lg:w-8 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+            </svg>
+          </div>
+          <div>
+            <h2 className="text-xl lg:text-2xl font-bold">Join a Club to Participate</h2>
+            <p className="text-sm lg:text-base">You must join a club before you can join a tournament. Please select or create a club to get started.</p>
+            {/* Optional: Add a button or link to join/create a club if available */}
+            {/* <Button className="mt-2 bg-white text-red-600 hover:bg-gray-100">Join a Club</Button> */}
+          </div>
+        </div>
+      )}
       <div className="bg-blue-600 rounded-lg p-4 lg:p-6 mb-6 flex items-center space-x-4">
         <div className="bg-yellow-400 rounded-full p-2 lg:p-3">
           <svg className="h-6 w-6 lg:h-8 lg:w-8 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -255,6 +273,7 @@ export default function Component() {
           const isFull = tournament.joinedClubIds?.length == tournament.maxTeams;
 
           return (
+            
             tournament?.id && (
               <TournamentCard key={tournament.id} tournament={tournament}>
                 {userClub && isCaptain && (


### PR DESCRIPTION
Changes:
- Allow admins to manage tournament on the tournament page itself
- Card informing users without a club that they need to join one before joining a tournament
- Password validity made visible while typing, instead of having to click the eye icon
- User profile now has a button routing them to the clubs page